### PR TITLE
Fix for typo in Atlassian

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ List of projects that provide terminal user interfaces
 - [calcure](https://github.com/anufrievroman/calcure) Modern TUI calendar and task manager with minimal and customizable UI.
 - [calcurse](https://calcurse.org/) calendar and scheduling application for the command line
 - [fml](https://github.com/wick3dr0se/fml) :file_folder: A stupid simple, fast file manager written in BASH v4.2+
-- [fjira](https://github.com/mk-5/fjira) TUI application for Attlasian Jira
+- [fjira](https://github.com/mk-5/fjira) TUI application for Atlassian Jira
 - [goful](https://github.com/anmitsu/goful) a powerful TUI file manager written in Go
 - [hledger-ui](https://github.com/simonmichael/hledger) A fast TUI for browsing double entry bookkeeping data
 - [h-m-m](https://github.com/nadrad/h-m-m) Hackers Mind Map


### PR DESCRIPTION
https://github.com/rothgar/awesome-tuis/pull/134

there is recent comment from @huyz about typo in word `Atlassian` / here we have a fix for it.